### PR TITLE
Turn subdomain name into link in DNS page.

### DIFF
--- a/app/views/subdomains/show.html.erb
+++ b/app/views/subdomains/show.html.erb
@@ -3,7 +3,7 @@
 <h1 class="heading break-word">
   <span>
     Subdomain:
-    <span class="h1 muted"><%= @subdomain.full_url %></span>
+    <a class="h1 muted" href="http://<%= @subdomain.full_url %>"><%= @subdomain.full_url %></a>
     <%= badge_for @subdomain.status_description, class: "bg-#{@subdomain.status_type} h4 ml0" %>
   </span>
   <%= link_to 'Edit', edit_subdomain_path(@subdomain), class: 'btn bg-ino' %>

--- a/app/views/subdomains/show.html.erb
+++ b/app/views/subdomains/show.html.erb
@@ -3,7 +3,7 @@
 <h1 class="heading break-word">
   <span>
     Subdomain:
-    <a class="h1 muted" href="http://<%= @subdomain.full_url %>"><%= @subdomain.full_url %></a>
+    <a class="h1 muted" href="http://<%= @subdomain.full_url %>" target="_blank" rel="noopener noreferrer"><%= @subdomain.full_url %></a>
     <%= badge_for @subdomain.status_description, class: "bg-#{@subdomain.status_type} h4 ml0" %>
   </span>
   <%= link_to 'Edit', edit_subdomain_path(@subdomain), class: 'btn bg-ino' %>


### PR DESCRIPTION
This is a quick solution for #13. This has 1 side effect and 1 potentially undesirable behavior. First of all, it adds an underline to the subdomain link. While this is easily fixed, I prefer to make the least amount of changes possible. Additionally, since it is a link, an underline may be appropriate. Second of all, it links with http and not https. This is due to us not knowing if the website is https compatible and playing it safe. Without keeping track if all the subdomains are https compatible, this is the best solution that I know of.

This is a draft because it is not tested and I do not have time to test this commit for another hour or so, but since this is a single line change I doubt it will change anything else.